### PR TITLE
Tighten referrer policy to avoid sending origin over unsecured HTTP

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <link rel='shortcut icon' type='image/svg+xml' href='/favicon.svg'>
     <link rel='shortcut icon' type='image/vnd.microsoft.icon' href='/favicon.ico'>
     
-    <meta name="referrer" content="origin-when-cross-origin" />
+    <meta name="referrer" content="strict-origin-when-cross-origin" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Fediwall</title>
   </head>


### PR DESCRIPTION
...by changing from `origin-when-cross-origin` to `strict-origin-when-cross-origin`.