### PR TITLE
src/defaults.ts: add fedi.buzz to servers

### DIFF
--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -4,7 +4,7 @@ import { type Config } from '@/types';
 // Fallback configuration in case the site config fails to load or is missing required fields.
 // TODO: Maybe just fail in that case and not hard-code mastodon.social?
 export const fallbackConfig: Config = {
-    servers: ["mastodon.social"],
+    servers: ["mastodon.social", "fedi.buzz"],
     tags: ["foss", "cats", "dogs"],
     accounts: [],
 


### PR DESCRIPTION
#FediBuzz tries hard to see a lot of the Fediverse. In preparation for #38c3, I added the API that is used by this project.

As storing Fediverse content is regarded critically (really), #FediBuzz will only start collecting posts for a queried hashtag for up to 24 hours. That means the initially returned results will be empty if that hashtag hasn't been queried recently.